### PR TITLE
feat: add support for hostinstall

### DIFF
--- a/build_tools/ERBuild.cmake
+++ b/build_tools/ERBuild.cmake
@@ -129,8 +129,8 @@ macro(ER_PACK)
   
   set(CPACK_PACKAGE_DIRECTORY "/opt/debs")
 
-  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Global Scope Kft <info@globalscope.info>")
-  set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://globalscope.info/")
+  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Effective Range Kft. <info@effective-range.com>")
+  set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://www.effective-range.com/")
 
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "${${PROJECT_NAME}_DEBDEPS}" )
 

--- a/build_tools/dpkgdeps
+++ b/build_tools/dpkgdeps
@@ -20,7 +20,7 @@ import re
 import subprocess
 import contextlib
 import os
-from typing import Optional, Union
+from typing import Optional, Union, Callable
 from pathlib import Path as path
 
 
@@ -46,18 +46,26 @@ class Dependency:
     name: str
     ver: Optional[str]
     arch: Optional[str]
+    hostinstall: bool
 
     def specStr(self, arch=True):
         archStr = f":{self.arch}" if self.arch and arch else ""
         verStr = f"={self.ver}" if self.ver else ""
         return f"{self.name}{archStr}{verStr}"
 
+    def retarget(self, target_arch: str):
+        if target_arch == self.arch:
+            return self
+        return Dependency(self.name, self.ver, target_arch, self.hostinstall)
+
     @staticmethod
-    def Parse(s: str, target: str):
+    def Parse(s: str, target: str, *, hostinstall=False):
         m = depRe.match(s)
         assert m is not None
         res = m.groupdict()
-        return Dependency(res["name"], res.get("ver", None), res.get("arch") or target)
+        return Dependency(
+            res["name"], res.get("ver", None), res.get("arch") or target, hostinstall
+        )
 
 
 build_arch = (
@@ -70,10 +78,10 @@ build_arch = (
 def parseDependency(entry: Union[str, dict], arch: str) -> Optional[Dependency]:
     if isinstance(entry, str):
         return Dependency.Parse(entry.strip(), arch)
-    if (isinstance(entry["arch"], str) and arch == entry["arch"]) or (
-        arch in entry["arch"]
-    ):
-        return Dependency.Parse(entry["name"].strip(), arch)
+    archs: Union[str, list[str]] = entry.get("arch", arch)
+    hostinstall = entry.get("hostinstall", False)
+    if (isinstance(archs, str) and arch == archs) or (arch in archs) or hostinstall:
+        return Dependency.Parse(entry["name"].strip(), arch, hostinstall=hostinstall)
     return None
 
 
@@ -114,16 +122,17 @@ def print_deb_deps(deps: dict, arch: str):
 def run_in_buildroot(target_arch: str, /, *args):
     if build_arch != target_arch:
         cmd = ["schroot", "-d", "/", "-u", "root", "-c", "buildroot", "--", *args]
-    elif os.geteuid() == 0:
-        cmd = args
     else:
-        try:
-            subprocess.check_call(["sudo", "-n", "true"])
-        except subprocess.CalledProcessError:
-            raise RuntimeError(
-                "sudo is not available or password-less sudo is not configured "
-            )
-        cmd = ["sudo", "--", *args]
+        cmd = hostroot_cmd(args)
+    run_cmd(cmd)
+
+
+def run_in_hostroot(target_arch: str, /, *args):
+    cmd = hostroot_cmd(args)
+    run_cmd(cmd)
+
+
+def run_cmd(cmd):
     p = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
@@ -139,23 +148,57 @@ def run_in_buildroot(target_arch: str, /, *args):
         raise subprocess.CalledProcessError(ret, cmd)
 
 
-def run_in_buildroot_with_lock(target_arch: str, /, *args):
+def hostroot_cmd(args):
+    if os.geteuid() == 0:
+        cmd = args
+    else:
+        try:
+            subprocess.check_call(["sudo", "-n", "true"])
+        except subprocess.CalledProcessError:
+            raise RuntimeError(
+                "sudo is not available or password-less sudo is not configured "
+            )
+        cmd = ["sudo", "--", *args]
+    return cmd
+
+
+def run_with_lock(
+    target_arch: str,
+    callable: Callable[[str], None],
+    /,
+    *args,
+):
     lock = filelock.FileLock("/tmp/dpkgdeps.lock")
     with lock:
-        run_in_buildroot(target_arch, *args)
+        callable(target_arch, *args)
 
 
-def install_in_buildroot(args, allDeps):
+def run_in_buildroot_with_lock(target_arch: str, /, *args):
+    run_with_lock(target_arch, run_in_buildroot, *args)
+
+
+def run_in_hostroot_with_lock(target_arch: str, /, *args):
+    run_with_lock(target_arch, run_in_hostroot, *args)
+
+
+def install_in_root(arch: str, installer, allDeps):
     pkgs = [d.specStr() for d in allDeps]
-    run_in_buildroot_with_lock(args.arch, "apt", "update")
-
-    run_in_buildroot_with_lock(
-        args.arch,
+    installer(arch, "apt", "update")
+    installer(
+        arch,
         "apt",
         "install",
         "-y",
         *pkgs,
     )
+
+
+def install_in_buildroot(args, allDeps):
+    install_in_root(args.arch, run_in_buildroot_with_lock, allDeps)
+
+
+def install_in_hostroot(args, allDeps):
+    install_in_root(build_arch, run_in_hostroot_with_lock, allDeps)
 
 
 def main():
@@ -175,8 +218,11 @@ def main():
         if args.debdeps:
             print_deb_deps(deps, args.arch)
             return
-
-        install_in_buildroot(args, get_all_dependencies(args.arch, deps))
+        all_deps = get_all_dependencies(args.arch, deps)
+        install_in_buildroot(args, all_deps)
+        install_in_hostroot(
+            args, set(d.retarget(build_arch) for d in all_deps if d.hostinstall)
+        )
 
 
 def get_all_dependencies(arch: str, deps: dict):

--- a/test/120-testcmake.sh
+++ b/test/120-testcmake.sh
@@ -66,6 +66,7 @@ dpkg -c /opt/debs/test_complex_build_1.0.0-1_${DEB_ARCH}.deb | grep -E "./usr/lo
 dpkg -I /opt/debs/test_complex_build_1.0.0-1_${DEB_ARCH}.deb | grep -E "Depends:.*libncurses6.*$"
 dpkg -I /opt/debs/test_complex_build_1.0.0-1_${DEB_ARCH}.deb | grep -E "Depends:.*libstdc\+\+6.*$"
 dpkg -I /opt/debs/test_complex_build_1.0.0-1_${DEB_ARCH}.deb | grep -E "Depends:.*libc6.*$"
+dpkg -I /opt/debs/test_complex_build_1.0.0-1_${DEB_ARCH}.deb | grep -E "Depends:.*libprotobuf.*$"
 
 # Test for complex dep specification
 if [ $DEB_ARCH = "armhf" ]; then

--- a/test/build_complex_test/deps.json
+++ b/test/build_complex_test/deps.json
@@ -6,7 +6,8 @@
             "arch": [
                 "armhf"
             ]
-        }
+        },
+        "libprotobuf23"
     ],
     "build_deps": [
         "libc6-dev",
@@ -15,6 +16,11 @@
             "arch": [
                 "armhf"
             ]
-        }
+        },
+        {
+            "name": "protobuf-compiler",
+            "hostinstall": true
+        },
+        "libprotobuf-dev"
     ]
 }

--- a/test/build_complex_test/testbin/CMakeLists.txt
+++ b/test/build_complex_test/testbin/CMakeLists.txt
@@ -1,13 +1,23 @@
 
 
-ER_ADD_EXECUTABLE(complexbin SOURCES main.cpp)
+
+# example for generating source files (with hostinstall feature)
+find_package(Protobuf REQUIRED)
+
+
+# By default generates to ${CMAKE_CURRENT_BINARY_DIR}
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS test.proto PROTOC_OUT_DIR)
+
+ER_ADD_EXECUTABLE(complexbin SOURCES main.cpp ${PROTO_SRCS} ${PROTO_HDRS})
+# ${CMAKE_CURRENT_BINARY_DIR} is added as an include directory to be able to pull in generated source files
+target_include_directories(complexbin PRIVATE ${Protobuf_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
 
 # checking xpkg-config operation
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(NCurses REQUIRED ncurses)
 
-target_link_libraries(complexbin complexlib)
+target_link_libraries(complexbin complexlib ${Protobuf_LIBRARIES})
 
 # FIXME: this will require devc refatoring that's upcoming
 # verifying xpkg-config operation for now...

--- a/test/build_complex_test/testbin/main.cpp
+++ b/test/build_complex_test/testbin/main.cpp
@@ -2,6 +2,8 @@
 // #include <ncurses.h>
 #include <iostream>
 
+#include <test.pb.h>
+
 int main(int, char**)
 {
     std::cout <<"Meaning of life is " << meaning_of_life() << '\n';

--- a/test/build_complex_test/testbin/test.proto
+++ b/test/build_complex_test/testbin/test.proto
@@ -1,0 +1,27 @@
+syntax = "proto2";
+
+package test;
+
+message Person {
+  optional string name = 1;
+  optional int32 id = 2;
+  optional string email = 3;
+
+  enum PhoneType {
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
+  }
+
+  message PhoneNumber {
+    optional string number = 1;
+    optional PhoneType type = 2 [default = PHONE_TYPE_HOME];
+  }
+
+  repeated PhoneNumber phones = 4;
+}
+
+message AddressBook {
+  repeated Person people = 1;
+}


### PR DESCRIPTION
In the deps json, when an entry is an object, a new attribute can be specified with key `hostinstall`. This will cause the listed dependency to be also installed in the host rootfs. This can be used for installing packages that contains source generators for example. Added a test with protobuf compiler for illustration.
This implements #6 