### PR TITLE
feat: added fix broken links script

### DIFF
--- a/build_tools/dpkgdeps
+++ b/build_tools/dpkgdeps
@@ -141,7 +141,7 @@ def run_cmd(cmd):
     )
     assert p.stdout
     for line in iter(p.stdout.readline, ""):
-        get_logger().info(line.replace("\n", ""))
+        get_logger().info(line.replace("\n", "").strip())
     p.stdout.close()
     ret = p.wait()
     if ret != 0:
@@ -181,10 +181,10 @@ def run_in_hostroot_with_lock(target_arch: str, /, *args):
     run_with_lock(target_arch, run_in_hostroot, *args)
 
 
-def install_in_root(arch: str, installer, allDeps):
+def install_in_root(arch: str, runner, allDeps):
     pkgs = [d.specStr() for d in allDeps]
-    installer(arch, "apt", "update")
-    installer(
+    runner(arch, "apt", "update")
+    runner(
         arch,
         "apt",
         "install",
@@ -223,6 +223,13 @@ def main():
         install_in_hostroot(
             args, set(d.retarget(build_arch) for d in all_deps if d.hostinstall)
         )
+        if args.arch != build_arch:
+            # TODO: factor out build root path as a parameter to script
+            run_in_hostroot_with_lock(
+                args.arch,
+                os.path.join(os.path.dirname(__file__), "fixbrokenlinks.sh"),
+                "/var/chroot/buildroot",
+            )
 
 
 def get_all_dependencies(arch: str, deps: dict):

--- a/build_tools/fixbrokenlinks.sh
+++ b/build_tools/fixbrokenlinks.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+BUILD_ROOT=$1
+
+if [ ! -d "$BUILD_ROOT" ]; then
+    echo "Error: $BUILD_ROOT is not a directory"
+    echo "Usage: $0  <buildroot>"
+    exit 1
+fi
+
+
+BROKEN_LINKS=$(find $BUILD_ROOT -xtype l -name *.so)
+
+for LINK in $BROKEN_LINKS; do
+    TARGET=$(readlink $LINK)
+    NEW_TARGET=$(realpath -s --relative-to=$(dirname $LINK) $BUILD_ROOT/$TARGET)
+    if [ -z "$NEW_TARGET" ]; then
+        echo "Error: Could not find target for $LINK"
+        exit 1
+    fi
+    ln -svf $NEW_TARGET $LINK
+done

--- a/dev_tools/link_devc
+++ b/dev_tools/link_devc
@@ -30,4 +30,5 @@ else
 fi
 
 ln -f -v -s /devc/build_tools/dpkgdeps /usr/bin/dpkgdeps
+ln -f -v -s /devc/build_tools/fixbrokenlinks.sh /usr/bin/fixbrokenlinks.sh
 ln -f -v -s /devc/build_tools/ERBuild.cmake $(find /usr/share/ -name ERBuild.cmake | head -n1)

--- a/scripts/build_steps_arm64/130-fixbrokenlinks
+++ b/scripts/build_steps_arm64/130-fixbrokenlinks
@@ -1,0 +1,1 @@
+../build_steps_armhf/130-fixbrokenlinks

--- a/scripts/build_steps_armhf/115-dpkgdeps
+++ b/scripts/build_steps_armhf/115-dpkgdeps
@@ -16,6 +16,7 @@ cp -vf /home/crossbuilder/build_tools/ERBuild.cmake /usr/share/cmake-$CMAKE_VERS
 pip install -r /home/crossbuilder/build_tools/requirements.txt
 
 install -v /home/crossbuilder/build_tools/dpkgdeps /usr/bin/
+install -v /home/crossbuilder/build_tools/fixbrokenlinks.sh /usr/bin/
 
 # create debian directory for packages
 mkdir -p /opt/debs

--- a/scripts/build_steps_armhf/130-fixbrokenlinks
+++ b/scripts/build_steps_armhf/130-fixbrokenlinks
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 Ferenc Nandor Janky <ferenj@effective-range.com>
+# SPDX-FileCopyrightText: 2024 Attila Gombos <attila.gombos@effective-range.com>
+# SPDX-License-Identifier: MIT
+
+set -e
+
+STEP_DESCRIPTION="Fixing broken symlinks in buildroot"
+source "$(dirname $0)/../build_common"
+
+"$(dirname $0)/../../build_tools/fixbrokenlinks.sh" /var/chroot/buildroot
+

--- a/test/build_complex_test/CMakeLists.txt
+++ b/test/build_complex_test/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
 include(ERBuild NO_POLICY_SCOPE)
 
 project(test_complex_build VERSION 1.0.0 DESCRIPTION "This is a complex project to test the CMAKE build & pack environment")
 
-cmake_minimum_required(VERSION 3.22)
 
 ER_DEPS()
 

--- a/test/build_exe_test/CMakeLists.txt
+++ b/test/build_exe_test/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
 include(ERBuild NO_POLICY_SCOPE)
 
 project(test_exe_build VERSION 1.0.0 DESCRIPTION "This is a project to test the CMAKE build & pack environment")
 
-cmake_minimum_required(VERSION 3.22)
 
 ER_DEPS()
 

--- a/test/build_shared_lib_test/CMakeLists.txt
+++ b/test/build_shared_lib_test/CMakeLists.txt
@@ -1,9 +1,9 @@
+cmake_minimum_required(VERSION 3.22)
 include(ERBuild NO_POLICY_SCOPE)
 
 
 project(test_sharedlib_build VERSION 1.0.0 DESCRIPTION "This is a project to test the CMAKE build & pack environment for shared libraries")
 
-cmake_minimum_required(VERSION 3.22)
 
 ER_DEPS()
 

--- a/test/build_static_lib_test/CMakeLists.txt
+++ b/test/build_static_lib_test/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
 include(ERBuild NO_POLICY_SCOPE)
 
 project(test_staticlib_build VERSION 1.0.0 DESCRIPTION "This is a project to test the CMAKE build & pack environment for static libraries")
 
-cmake_minimum_required(VERSION 3.22)
 
 ER_DEPS()
 


### PR DESCRIPTION
Introduce a script that identifies and fixes broken symbolic links in the specified buildroot directory. Update installation scripts to include this new functionality.