### PR TITLE
Enhance dpkgdeps with multi-distro support and improved testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
         matrix:
           architecture: ["armhf", "amd64", "arm64"]
+          distro: ["bullseye", "bookworm"]
     
     steps:
       - name: Check out the repo
@@ -27,4 +28,4 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME  }}
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
       - name: Run CI tests
-        run: ${{github.workspace}}/test.sh ${{ matrix.architecture }}
+        run: ${{github.workspace}}/test.sh ${{ matrix.architecture }} ${{ matrix.distro }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,9 @@
     "python.testing.unittestArgs": [
         "-v",
         "-s",
-        "./build_tools",
+        "build_tools/dpkgdeps_src/test/",
         "-p",
-        "*test*.py"
+        "*_test.py"
     ],
     "python.testing.pytestEnabled": false,
     "python.testing.unittestEnabled": true

--- a/EffectiveRange-devc.code-workspace
+++ b/EffectiveRange-devc.code-workspace
@@ -5,6 +5,8 @@
 		}
 	],
 	"settings": {
-		"makefile.configureOnOpen": false
+		"makefile.configureOnOpen": false,
+		"editor.formatOnSave": true,
+		"python.testing.unittestEnabled": true,
 	}
 }

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ CROSS_BASE_IMAGE_VER=bullseye-slim
 colon := :
 $(colon) := :
 IMG_TAG=$(TARGET_NAME)-$$(date +%Y%m%d-%H%M%S)
+BASE_DISTRO=$(subst -slim,,$(CROSS_BASE_IMAGE_VER))
 
 .PHONY: base-armhf base-amd64 devc devc-armhf devc-amd64 build_driver cross-armhf devc-arm64
 
@@ -19,25 +20,25 @@ build_driver:
 cross-armhf: build_driver
 	CROSS_IMG_VER=$$(./scripts/gen_cross_hash $(DEVC_ARCH) TARGET/$(TARGET_NAME) 2>/dev/null ); echo Cross image version is $$CROSS_IMG_VER ;\
 	if [ "$$(./scripts/check_cross_base $(DEVC_ARCH) TARGET/$(TARGET_NAME))" = "true" ]; then \
-		docker buildx build --file Dockerfile-cross --tag effectiverange/$(DEVC_ARCH)-$(subst -slim,,$(CROSS_BASE_IMAGE_VER))-tools-cross$(:)$$CROSS_IMG_VER --build-arg BASE_IMAGE_VER=$(CROSS_BASE_IMAGE_VER) --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS) . ;\
+		docker buildx build --file Dockerfile-cross --tag effectiverange/$(DEVC_ARCH)-$(BASE_DISTRO)-tools-cross$(:)$$CROSS_IMG_VER --build-arg BASE_IMAGE_VER=$(CROSS_BASE_IMAGE_VER) --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS) . ;\
 	fi 
 
 base-armhf: cross-armhf
-	docker buildx build .  --file Dockerfile --tag effectiverange/armhf-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/armhf-tools-cross --build-arg BASE_IMAGE_VER=$$(./scripts/gen_cross_hash armhf TARGET/$(TARGET_NAME))  --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS)
+	docker buildx build .  --file Dockerfile --tag effectiverange/armhf-$(BASE_DISTRO)-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/armhf-tools-cross --build-arg BASE_IMAGE_VER=$$(./scripts/gen_cross_hash armhf TARGET/$(TARGET_NAME))  --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS)
 
 base-amd64:
-	docker buildx build . --file Dockerfile --tag effectiverange/amd64-tools-base$(:)$(IMG_TAG) --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS) --build-arg BUILD_ARCH=amd64
+	docker buildx build . --file Dockerfile --tag effectiverange/amd64-$(BASE_DISTRO)-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_VER=$(CROSS_BASE_IMAGE_VER) --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS) --build-arg BUILD_ARCH=amd64
 
 base-arm64: cross-armhf
-	docker buildx build . --file Dockerfile --tag effectiverange/arm64-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/arm64-tools-cross --build-arg BASE_IMAGE_VER=$$(./scripts/gen_cross_hash armhf TARGET/$(TARGET_NAME)) --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS) --build-arg BUILD_ARCH=arm64
+	docker buildx build . --file Dockerfile --tag effectiverange/arm64-$(BASE_DISTRO)-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/arm64-tools-cross --build-arg BASE_IMAGE_VER=$$(./scripts/gen_cross_hash armhf TARGET/$(TARGET_NAME)) --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS) --build-arg BUILD_ARCH=arm64
 
 
 devc-armhf:
-	docker buildx build --file Dockerfile-devc --tag effectiverange/er-devc-armhf$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/armhf-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=armhf .
+	docker buildx build --file Dockerfile-devc --tag effectiverange/er-devc-armhf-$(BASE_DISTRO)$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/armhf-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=armhf .
 
 devc-amd64:
-	docker buildx build --file Dockerfile-devc --tag  effectiverange/er-devc-amd64$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/amd64-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=amd64 .
+	docker buildx build --file Dockerfile-devc --tag  effectiverange/er-devc-amd64-$(BASE_DISTRO)$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/amd64-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=amd64 .
 
 devc-arm64:
-	docker build --file Dockerfile-devc --tag  effectiverange/er-devc-arm64$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/arm64-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=arm64 .
+	docker build --file Dockerfile-devc --tag  effectiverange/er-devc-arm64-$(BASE_DISTRO)$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/arm64-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=arm64 .
 

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ base-arm64: cross-armhf
 
 
 devc-armhf:
-	docker buildx build --file Dockerfile-devc --tag effectiverange/er-devc-armhf-$(BASE_DISTRO)$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/armhf-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=armhf .
+	docker buildx build --file Dockerfile-devc --tag effectiverange/er-devc-armhf-$(BASE_DISTRO)$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/armhf-$(BASE_DISTRO)-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=armhf .
 
 devc-amd64:
-	docker buildx build --file Dockerfile-devc --tag  effectiverange/er-devc-amd64-$(BASE_DISTRO)$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/amd64-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=amd64 .
+	docker buildx build --file Dockerfile-devc --tag  effectiverange/er-devc-amd64-$(BASE_DISTRO)$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/amd64-$(BASE_DISTRO)-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=amd64 .
 
 devc-arm64:
-	docker build --file Dockerfile-devc --tag  effectiverange/er-devc-arm64-$(BASE_DISTRO)$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/arm64-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=arm64 .
+	docker build --file Dockerfile-devc --tag  effectiverange/er-devc-arm64-$(BASE_DISTRO)$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/arm64-$(BASE_DISTRO)-tools-base --build-arg BASE_IMAGE_VER=$(BASE_IMAGE_VER) --build-arg DEVC_ARCH=arm64 .
 

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ cross-armhf: build_driver
 	fi 
 
 base-armhf: cross-armhf
-	docker buildx build .  --file Dockerfile --tag effectiverange/armhf-$(BASE_DISTRO)-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/armhf-tools-cross --build-arg BASE_IMAGE_VER=$$(./scripts/gen_cross_hash armhf TARGET/$(TARGET_NAME))  --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS)
+	docker buildx build .  --file Dockerfile --tag effectiverange/armhf-$(BASE_DISTRO)-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/armhf-$(BASE_DISTRO)-tools-cross --build-arg BASE_IMAGE_VER=$$(./scripts/gen_cross_hash armhf TARGET/$(TARGET_NAME))  --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS)
 
 base-amd64:
 	docker buildx build . --file Dockerfile --tag effectiverange/amd64-$(BASE_DISTRO)-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_VER=$(CROSS_BASE_IMAGE_VER) --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS) --build-arg BUILD_ARCH=amd64
 
 base-arm64: cross-armhf
-	docker buildx build . --file Dockerfile --tag effectiverange/arm64-$(BASE_DISTRO)-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/arm64-tools-cross --build-arg BASE_IMAGE_VER=$$(./scripts/gen_cross_hash armhf TARGET/$(TARGET_NAME)) --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS) --build-arg BUILD_ARCH=arm64
+	docker buildx build . --file Dockerfile --tag effectiverange/arm64-$(BASE_DISTRO)-tools-base$(:)$(IMG_TAG) --build-arg BASE_IMAGE_REPO=effectiverange/arm64-$(BASE_DISTRO)-tools-cross --build-arg BASE_IMAGE_VER=$$(./scripts/gen_cross_hash armhf TARGET/$(TARGET_NAME)) --build-arg TARGET_DIR=TARGET/$(TARGET_NAME) --build-arg KEEP_BUILD_ARTIFACTS=$(KEEP_BUILD_ARTIFACTS) --build-arg BUILD_ARCH=arm64
 
 
 devc-armhf:

--- a/build_tools/dpkgdeps_src/dpkgdeps/dpkgdeps.py
+++ b/build_tools/dpkgdeps_src/dpkgdeps/dpkgdeps.py
@@ -41,6 +41,15 @@ def pushd(new_dir):
 depRe = re.compile(r"(?P<name>[^:]+)(?::(?P<arch>\w+))?(?:=(?P<ver>[\w\.\+-]+))?")
 
 
+def get_os_release():
+    with open("/etc/os-release") as f:
+        os_release = "".join(f.readlines())
+        m = re.match(r"VERSION_CODENAME=(\w+)", os_release)
+        if m is None:
+            raise ValueError("Cannot determine OS release")
+        return m.group(1)
+
+
 @dataclass(frozen=True, eq=True)
 class Dependency:
     name: str
@@ -85,13 +94,24 @@ def parseDependency(entry: Union[str, dict], arch: str) -> Optional[Dependency]:
     return None
 
 
-def get_deps_impl(deps: dict, key: str, arch: str):
-    depSet: set[Dependency] = set(
-        dep for d in deps.get(key, []) if (dep := parseDependency(d, arch)) is not None
-    )
+def get_deps_impl(deps: dict, key: str, arch: str, distro: str):
+    depSet = get_deps_by_key(deps, key, arch)
+    version = deps.get("version", 1)
+    if version >= 2:
+        distro_deps = deps.get(distro, {})
+        return depSet.union(get_deps_by_key(distro_deps, key, arch))
+
     # NOTE: It's enough to fetch direct dependencies, as if the packaging is correct
     # then there's no need for the transitive dependencies
     # In such case, for now we will add it into deps.json directly
+    return depSet
+
+
+def get_deps_by_key(deps, key, arch):
+    depSet: set[Dependency] = set(
+        dep for d in deps.get(key, []) if (dep := parseDependency(d, arch)) is not None
+    )
+
     return depSet
 
 
@@ -100,23 +120,23 @@ def get_ignore_deps(deps, arch):
     return ignored
 
 
-def get_deps(deps: dict, arch: str):
-    return get_deps_impl(deps, "deps", arch)
+def get_deps(deps: dict, arch: str, distro: str):
+    return get_deps_impl(deps, "deps", arch, distro)
 
 
-def get_build_deps(deps: dict, arch: str):
-    return get_deps_impl(deps, "build_deps", arch)
+def get_build_deps(deps: dict, arch: str, distro: str):
+    return get_deps_impl(deps, "build_deps", arch, distro)
 
 
-def deb_deps_str(deps: dict, arch: str):
+def deb_deps_str(deps: dict, arch: str, distro: str):
     # TODO: add support for versioning!!!
-    pkg_deps, _ = retrieve_deps(deps, arch)
+    pkg_deps, _ = retrieve_deps(deps, arch, distro)
     d = sorted(d.name for d in pkg_deps)
     return ",".join(d)
 
 
-def print_deb_deps(deps: dict, arch: str):
-    print(deb_deps_str(deps, arch))
+def print_deb_deps(deps: dict, arch: str, distro: str):
+    print(deb_deps_str(deps, arch, distro))
 
 
 def run_in_buildroot(target_arch: str, /, *args):
@@ -203,8 +223,9 @@ def install_in_hostroot(args, allDeps):
 
 def main():
     import sys
+
     sys.stderr.write(f"Invocation:{' '.join(sys.argv)}\n")
-    
+
     args = get_args()
     setup_logging(args)
     logger = get_logger()
@@ -217,11 +238,11 @@ def main():
             return
 
         # add ignore from parent to child
-
+        os_release = get_os_release()
         if args.debdeps:
-            print_deb_deps(deps, args.arch)
+            print_deb_deps(deps, args.arch, os_release)
             return
-        all_deps = get_all_dependencies(args.arch, deps)
+        all_deps = get_all_dependencies(args.arch, os_release, deps)
         install_in_buildroot(args, all_deps)
         install_in_hostroot(
             args, set(d.retarget(build_arch) for d in all_deps if d.hostinstall)
@@ -235,8 +256,8 @@ def main():
             )
 
 
-def get_all_dependencies(arch: str, deps: dict):
-    pkg_deps, build_deps = retrieve_deps(deps, arch)
+def get_all_dependencies(arch: str, distro: str, deps: dict):
+    pkg_deps, build_deps = retrieve_deps(deps, arch, distro)
     return pkg_deps.union(build_deps)
 
 
@@ -323,9 +344,9 @@ def gen_cache_digest(allDeps):
     return digest
 
 
-def retrieve_deps(deps, arch: str):
-    pkgDeps = get_deps(deps, arch)
-    buildDeps = get_build_deps(deps, arch)
+def retrieve_deps(deps, arch: str, distro: str):
+    pkgDeps = get_deps(deps, arch, distro)
+    buildDeps = get_build_deps(deps, arch, distro)
     return pkgDeps, buildDeps
 
 

--- a/build_tools/dpkgdeps_src/dpkgdeps/dpkgdeps.py
+++ b/build_tools/dpkgdeps_src/dpkgdeps/dpkgdeps.py
@@ -44,7 +44,7 @@ depRe = re.compile(r"(?P<name>[^:]+)(?::(?P<arch>\w+))?(?:=(?P<ver>[\w\.\+-]+))?
 def get_os_release():
     with open("/etc/os-release") as f:
         os_release = "".join(f.readlines())
-        m = re.match(r"VERSION_CODENAME=(\w+)", os_release)
+        m = re.match(r".*VERSION_CODENAME=(\w+).*", os_release, re.DOTALL)
         if m is None:
             raise ValueError("Cannot determine OS release")
         return m.group(1)

--- a/build_tools/dpkgdeps_src/dpkgdeps/dpkgdeps.py
+++ b/build_tools/dpkgdeps_src/dpkgdeps/dpkgdeps.py
@@ -247,7 +247,7 @@ def main():
             # TODO: factor out build root path as a parameter to script
             run_in_hostroot_with_lock(
                 args.arch,
-                os.path.join(os.path.dirname(__file__), "fixbrokenlinks.sh"),
+                "/usr/bin/fixbrokenlinks.sh",
                 "/var/chroot/buildroot",
             )
 

--- a/build_tools/dpkgdeps_src/test/dpkgdeps_test.py
+++ b/build_tools/dpkgdeps_src/test/dpkgdeps_test.py
@@ -1,4 +1,4 @@
-from dpkgdeps import deb_deps_str, get_all_dependencies, retrieve_deps
+from dpkgdeps.dpkgdeps import deb_deps_str, get_all_dependencies, retrieve_deps
 
 import unittest
 import json
@@ -25,7 +25,7 @@ class Test(unittest.TestCase):
 
     def test_simple_parsing(self):
 
-        deps = get_all_dependencies("armhf", self.simple_deps())
+        deps = get_all_dependencies("armhf", "bullseye", self.simple_deps())
         self.assertEqual(len(deps), 3)
         depNames = [d.name for d in deps]
         self.assertIn("libstdc++6", depNames)
@@ -35,7 +35,7 @@ class Test(unittest.TestCase):
         self.assertTrue(all(d.ver is None for d in deps))
 
     def test_simple_debdeps(self):
-        deps = deb_deps_str(self.simple_deps(), "armhf")
+        deps = deb_deps_str(self.simple_deps(), "armhf", "bullseye")
         self.assertIn("libstdc++6", deps)
         self.assertIn("libc6", deps)
 
@@ -76,8 +76,51 @@ class Test(unittest.TestCase):
 """
         return json.loads(text)
 
+    def multidistro_deps(self):
+        text = """
+{
+    "version":2,
+    "deps": [
+        "libstdc++6",
+        {
+            "name": "libpigpio1",
+            "arch": [
+                "armhf"
+            ]
+        }
+    ],
+    "bullseye": {
+        "deps": [
+            "libprotobuf23"
+        ]
+    },
+    "bookworm": {
+        "deps": [
+            "libprotobuf32"
+        ]
+    },
+    "build_deps": [
+        "libc6-dev",
+        {
+            "name": "libpigpio-dev",
+            "arch": [
+                "armhf"
+            ]
+        },
+        {
+            "name": "protobuf-compiler",
+            "hostinstall": true
+        },
+        "libprotobuf-dev"
+    ]
+}
+"""
+        return json.loads(text)
+
     def test_complex_parsing_w_hostinstall(self):
-        deps = get_all_dependencies("arm64", self.complex_deps_w_hostinstall())
+        deps = get_all_dependencies(
+            "arm64", "bullseye", self.complex_deps_w_hostinstall()
+        )
         self.assertEqual(len(deps), 3)
         depNames = [d.name for d in deps]
         self.assertIn("libstdc++6", depNames)
@@ -89,7 +132,7 @@ class Test(unittest.TestCase):
         self.assertTrue(protod[0].hostinstall)
 
     def test_complex_parsing(self):
-        deps = get_all_dependencies("arm64", self.complex_deps())
+        deps = get_all_dependencies("arm64", "bullseye", self.complex_deps())
         self.assertEqual(len(deps), 2)
         depNames = [d.name for d in deps]
         self.assertIn("libstdc++6", depNames)
@@ -98,12 +141,12 @@ class Test(unittest.TestCase):
         self.assertTrue(all(d.ver is None for d in deps))
 
     def test_complex_parsing_debdeps(self):
-        deps = deb_deps_str(self.complex_deps(), "arm64")
+        deps = deb_deps_str(self.complex_deps(), "arm64", "bullseye")
         self.assertIn("libstdc++6", deps)
         self.assertNotIn("libc6", deps)
 
     def test_complex_parsing2(self):
-        deps = get_all_dependencies("armhf", self.complex_deps())
+        deps = get_all_dependencies("armhf", "bullseye", self.complex_deps())
         self.assertEqual(len(deps), 3)
         depNames = [d.name for d in deps]
         self.assertIn("libstdc++6", depNames)
@@ -113,12 +156,12 @@ class Test(unittest.TestCase):
         self.assertTrue(all(d.ver is None for d in deps))
 
     def test_complex_parsing2_debdeps(self):
-        deps = deb_deps_str(self.complex_deps(), "armhf")
+        deps = deb_deps_str(self.complex_deps(), "armhf", "bullseye")
         self.assertIn("libstdc++6", deps)
         self.assertIn("libc6", deps)
 
     def test_complex_parsing3(self):
-        deps = get_all_dependencies("amd64", self.complex_deps())
+        deps = get_all_dependencies("amd64", "bullseye", self.complex_deps())
         self.assertEqual(len(deps), 1)
         depNames = [d.name for d in deps]
         self.assertIn("libstdc++6", depNames)
@@ -126,9 +169,40 @@ class Test(unittest.TestCase):
         self.assertTrue(all(d.ver is None for d in deps))
 
     def test_complex_parsing3_debdeps(self):
-        deps = deb_deps_str(self.complex_deps(), "amd64")
+        deps = deb_deps_str(self.complex_deps(), "amd64", "bullseye")
         self.assertIn("libstdc++6", deps)
         self.assertNotIn("libc6", deps)
+
+    def test_multidistro_parsing(self):
+        deps_be = get_all_dependencies("armhf", "bullseye", self.multidistro_deps())
+        depNames = [d.name for d in deps_be]
+        self.assertEqual(len(deps_be), 7)
+        self.assertIn("libstdc++6", depNames)
+        self.assertIn("libpigpio1", depNames)
+        self.assertIn("libprotobuf23", depNames)
+        self.assertIn("libc6-dev", depNames)
+        self.assertIn("libpigpio-dev", depNames)
+        self.assertIn("protobuf-compiler", depNames)
+        self.assertIn("libprotobuf-dev", depNames)
+
+        deps_bw = get_all_dependencies("armhf", "bookworm", self.multidistro_deps())
+        depNames = [d.name for d in deps_bw]
+        self.assertEqual(len(deps_bw), 7)
+        self.assertIn("libstdc++6", depNames)
+        self.assertIn("libpigpio1", depNames)
+        self.assertIn("libprotobuf32", depNames)
+        self.assertIn("libc6-dev", depNames)
+        self.assertIn("libpigpio-dev", depNames)
+        self.assertIn("protobuf-compiler", depNames)
+        self.assertIn("libprotobuf-dev", depNames)
+
+    def test_multi_distro_debdeps_str(self):
+        deps_be = deb_deps_str(self.multidistro_deps(), "armhf", "bullseye")
+        self.assertIn("libprotobuf23", deps_be)
+        self.assertNotIn("libprotobuf32", deps_be)
+        deps_bw = deb_deps_str(self.multidistro_deps(), "armhf", "bookworm")
+        self.assertIn("libprotobuf32", deps_bw)
+        self.assertNotIn("libprotobuf23", deps_bw)
 
 
 if __name__ == "__main__":

--- a/build_tools/dpkgdeps_src/test/dpkgdeps_test.py
+++ b/build_tools/dpkgdeps_src/test/dpkgdeps_test.py
@@ -2,6 +2,7 @@ from dpkgdeps.dpkgdeps import (
     deb_deps_str,
     get_all_dependencies,
     get_os_release,
+    merge_json,
     retrieve_deps,
 )
 
@@ -212,6 +213,10 @@ class Test(unittest.TestCase):
     def test_version_codename(self):
         codename = get_os_release()
         self.assertTrue(codename is not None)
+
+    def test_merge_json(self):
+        merged = merge_json(self.simple_deps(), self.multidistro_deps())
+        self.assertEqual(merged["version"], 2)
 
 
 if __name__ == "__main__":

--- a/build_tools/dpkgdeps_src/test/dpkgdeps_test.py
+++ b/build_tools/dpkgdeps_src/test/dpkgdeps_test.py
@@ -1,4 +1,9 @@
-from dpkgdeps.dpkgdeps import deb_deps_str, get_all_dependencies, retrieve_deps
+from dpkgdeps.dpkgdeps import (
+    deb_deps_str,
+    get_all_dependencies,
+    get_os_release,
+    retrieve_deps,
+)
 
 import unittest
 import json
@@ -203,6 +208,10 @@ class Test(unittest.TestCase):
         deps_bw = deb_deps_str(self.multidistro_deps(), "armhf", "bookworm")
         self.assertIn("libprotobuf32", deps_bw)
         self.assertNotIn("libprotobuf23", deps_bw)
+
+    def test_version_codename(self):
+        codename = get_os_release()
+        self.assertTrue(codename is not None)
 
 
 if __name__ == "__main__":

--- a/scripts/build_steps_amd64/120-build_deps
+++ b/scripts/build_steps_amd64/120-build_deps
@@ -19,16 +19,13 @@ apt install -y --no-install-recommends python3 python3-pip python3-dev python3-w
 # Install library dev packages
 apt install -y --no-install-recommends libsystemd-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev
 
-if [ ${DEBOOTSTRAP_TARGET} == "bullseye" ]
-then
-   python3 -m pip install pipx
-   python3 -m pipx ensurepath
-else
-   apt install -y --no-install-recommends pipx
-   pipx ensurepath
-fi
+# Bootstrap pipx with pipx
+python3 -m venv /tmp/bootstrap_pipx
+/tmp/bootstrap_pipx/bin/pip install pipx
+PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin /tmp/bootstrap_pipx/bin/pipx install --global pipx
+rm -rf /tmp/bootstrap_pipx
 
 # Install python build packages
-pipx install ninja
-pipx install patchelf 
-pipx install meson
+pipx install --global ninja
+pipx install --global patchelf 
+pipx install --global meson

--- a/scripts/build_steps_armhf/05-schroot_build_deps
+++ b/scripts/build_steps_armhf/05-schroot_build_deps
@@ -21,19 +21,17 @@ chroot /var/chroot/buildroot apt install -y --no-install-recommends cmake ninja-
 # Install packages for python development
 chroot /var/chroot/buildroot apt install -y --no-install-recommends python3 python3-pip python3-dev python3-wheel python3-stdeb python3-venv  python3-virtualenv dh-virtualenv dh-python python3-all
 
-if [ ${DEBOOTSTRAP_TARGET} == "bullseye" ]
-then
-    chroot /var/chroot/buildroot python3 -m pip install pipx
-    chroot /var/chroot/buildroot python3 -m pipx ensurepath
-else
-    chroot /var/chroot/buildroot apt install -y --no-install-recommends pipx
-    chroot /var/chroot/buildroot pipx ensurepath
-fi
+# Bootstrap pipx with pipx
+chroot /var/chroot/buildroot python3 -m venv /tmp/bootstrap_pipx
+chroot /var/chroot/buildroot /tmp/bootstrap_pipx/bin/pip install  pipx
+chroot /var/chroot/buildroot /usr/bin/env PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin /tmp/bootstrap_pipx/bin/pipx install --global pipx
+chroot /var/chroot/buildroot rm -rf /tmp/bootstrap_pipx
+
 
 # Install library dev packages
 chroot /var/chroot/buildroot apt install -y --no-install-recommends libsystemd-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev
 
 # Install python build packages
-chroot /var/chroot/buildroot pipx install ninja
-chroot /var/chroot/buildroot pipx install patchelf 
-chroot /var/chroot/buildroot pipx install meson
+chroot /var/chroot/buildroot pipx install --global ninja
+chroot /var/chroot/buildroot pipx install --global patchelf 
+chroot /var/chroot/buildroot pipx install --global meson

--- a/scripts/build_steps_armhf/115-dpkgdeps
+++ b/scripts/build_steps_armhf/115-dpkgdeps
@@ -13,7 +13,7 @@ CMAKE_VERSION=$(cmake --version | grep 'cmake version' | sed -r 's/cmake version
 
 cp -vf /home/crossbuilder/build_tools/ERBuild.cmake /usr/share/cmake-$CMAKE_VERSION/Modules/ || true
 
-pipx install  /home/crossbuilder/build_tools/dpkgdeps_src
+pipx install --global /home/crossbuilder/build_tools/dpkgdeps_src
 
 install -v /home/crossbuilder/build_tools/fixbrokenlinks.sh /usr/bin/
 

--- a/scripts/build_steps_armhf/117-python_build_deps
+++ b/scripts/build_steps_armhf/117-python_build_deps
@@ -11,5 +11,5 @@ source "$(dirname $0)/../build_common"
 
 apt install -y --no-install-recommends python3-flake8 python3-mypy python3-coverage python3-pytest 
 
-pipx install gcovr
-pipx install markdownify
+pipx install --global gcovr
+pipx install --global markdownify

--- a/test.sh
+++ b/test.sh
@@ -26,7 +26,7 @@ elif [ $BUILD_ARCH == "arm64" ]
 then
 TARGET=AARCH64-${DISTRO^^}
 else
-TARGET=$BUILD_ARCH-${DISTRO^^}
+TARGET=${BUILD_ARCH^^}-${DISTRO^^}
 fi
 
 

--- a/test.sh
+++ b/test.sh
@@ -3,26 +3,37 @@
 # SPDX-License-Identifier: MIT
 
 set -e
+ROOT_DIR="$(dirname $0)"
 BUILD_ARCH="$1"
-TARGET="$2"
+DISTRO="$2"
 
 if [ -z "$BUILD_ARCH" ]
 then
-echo "Usage: $0  <BUILD_ARCH> [<TARGET>]"
+echo "Usage: $0  <BUILD_ARCH> [<DISTRO>]"
 exit 1
 fi
-
-if [ -z "$TARGET" ]
-then
-echo "Usage: $0  [<TARGET>]"
-exit 1
-fi
-
-DISTRO=$(grep "VERSION_CODENAME=" $(dirname $0)/TARGET/$TARGET/target | cut -d "=" -f 2)
 
 if [ -z "$DISTRO" ]
 then
-echo "Not able to determine the distro from file $(dirname $0)/TARGET/$TARGET/target"
+echo "Usage: $0  [<DISTRO>]"
+exit 1
+fi
+
+if [ $BUILD_ARCH == "amd64" ]
+then
+TARGET=ARMHF-${DISTRO^^}
+elif [ $BUILD_ARCH == "arm64" ]
+then
+TARGET=AARCH64-${DISTRO^^}
+else
+TARGET=$BUILD_ARCH-${DISTRO^^}
+fi
+
+
+
+if [ ! -d "$ROOT_DIR/TARGET/$TARGET" ]
+then
+echo "Target directory $TARGET does not exist!"
 exit 1
 fi
 
@@ -30,16 +41,16 @@ fi
 
 python3 -m venv /tmp/testvenv
 
-/tmp/testvenv/bin/python3 -m pip install $(dirname $0)/build_tools/dpkgdeps_src
-/tmp/testvenv/bin/python3 -m unittest discover -s $(dirname $0)/build_tools/dpkgdeps_src/test/  -p *test.py
+/tmp/testvenv/bin/python3 -m pip install $ROOT_DIR/build_tools/dpkgdeps_src
+/tmp/testvenv/bin/python3 -m unittest discover -s $ROOT_DIR/build_tools/dpkgdeps_src/test/  -p *test.py
 
 IMG_ID=$(uuidgen)
 
-make -C "$(dirname $0)" base-$BUILD_ARCH TARGET_NAME=$TARGET CROSS_BASE_IMAGE_VER=$DISTRO-slim IMG_TAG=$IMG_ID
+make -C "$ROOT_DIR" base-$BUILD_ARCH TARGET_NAME=$TARGET CROSS_BASE_IMAGE_VER=$DISTRO-slim IMG_TAG=$IMG_ID
 
-make -C "$(dirname $0)" devc-$BUILD_ARCH  IMG_TAG=$IMG_ID BASE_IMAGE_VER=$IMG_ID CROSS_BASE_IMAGE_VER=$DISTRO-slim
+make -C "$ROOT_DIR" devc-$BUILD_ARCH  IMG_TAG=$IMG_ID BASE_IMAGE_VER=$IMG_ID CROSS_BASE_IMAGE_VER=$DISTRO-slim
 
-make -C "$(dirname $0)/test" clean test BASE_IMAGE_REPO=effectiverange/er-devc-$BUILD_ARCH-$DISTRO   BASE_IMAGE_VER=$IMG_ID 
+make -C "$ROOT_DIR/test" clean test BASE_IMAGE_REPO=effectiverange/er-devc-$BUILD_ARCH-$DISTRO   BASE_IMAGE_VER=$IMG_ID 
 
 
 

--- a/test.sh
+++ b/test.sh
@@ -30,6 +30,12 @@ TARGET=${BUILD_ARCH^^}-${DISTRO^^}
 fi
 
 
+#TODO: add missing target definition
+if [ $TARGET == "AARCH64-BOOKWORM" ]
+then
+echo "Skipping test for $TARGET"
+exit 0
+fi
 
 if [ ! -d "$ROOT_DIR/TARGET/$TARGET" ]
 then
@@ -37,12 +43,7 @@ echo "Target directory $TARGET does not exist!"
 exit 1
 fi
 
-#TODO: add missing target definition
-if [ $TARGET == "AARCH64-BOOKWORM" ]
-then
-echo "Skipping test for $TARGET"
-exit 0
-fi
+
 
 # python tests
 

--- a/test.sh
+++ b/test.sh
@@ -37,6 +37,13 @@ echo "Target directory $TARGET does not exist!"
 exit 1
 fi
 
+#TODO: add missing target definition
+if [ $TARGET == "AARCH64-BOOKWORM" ]
+then
+echo "Skipping test for $TARGET"
+exit 0
+fi
+
 # python tests
 
 python3 -m venv /tmp/testvenv

--- a/test/build_complex_test/deps.json
+++ b/test/build_complex_test/deps.json
@@ -6,9 +6,18 @@
             "arch": [
                 "armhf"
             ]
-        },
-        "libprotobuf23"
+        }
     ],
+    "bullseye":{
+        "deps":[
+            "libprotobuf23"
+        ]
+    },
+    "bookworm":{
+        "deps":[
+            "libprotobuf32"
+        ]
+    },
     "build_deps": [
         "libc6-dev",
         {


### PR DESCRIPTION
Introduce multi-distro support in dpkgdeps and update the Makefile and test scripts to utilize BASE_DISTRO for better image tagging and usage instructions. Improve test coverage and ensure compatibility across different distributions.